### PR TITLE
fix: prevent reuse of old password in password change process

### DIFF
--- a/src/controllers/apps/auth/user.controllers.js
+++ b/src/controllers/apps/auth/user.controllers.js
@@ -396,6 +396,10 @@ const resetForgottenPassword = asyncHandler(async (req, res) => {
 const changeCurrentPassword = asyncHandler(async (req, res) => {
   const { oldPassword, newPassword } = req.body;
 
+   if (oldPassword === newPassword) {
+    throw new ApiError(400, "New password can't be same as old password");
+  }
+  
   const user = await User.findById(req.user?._id);
 
   // check the old password


### PR DESCRIPTION
Added a validation to ensure the new password is not the same as the old password when updating the user's password.